### PR TITLE
Update git repository URL in build steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,7 +441,7 @@ BitKey is built with `TKLDev`_, the TurnKey GNU/Linux build system.
 
 	ssh tkldev
 	cd products
-	git-clone https://github.com/bitkey/bitkey
+	git-clone https://github.com/estevaocm/bitkey
 
 	cd bitkey
 	make


### PR DESCRIPTION
This change updates the git URL referenced in the build steps to point to the URL of this fork instead of the upstream repository.